### PR TITLE
バージョン表示時のステータスコードについて

### DIFF
--- a/Sources/mainc.m
+++ b/Sources/mainc.m
@@ -996,7 +996,7 @@ NSArray<id>* generateConverter (int argc, char *argv[]) {
                 break;
             case (OPTION_NUM - 2): // --version
                 version();
-                exit(1);
+                exit(0);
                 break;
             case (OPTION_NUM - 1): // --help
                 usage();


### PR DESCRIPTION
現在の TeX2img は `tex2img --version` するとステータスコードとして`1`が返るようです．ソースを調べたところ，`--version` オプションを処理する部分に `exit(1)` が明示的に書かれていたので単純に `exit(0)` に書き換えました．

これが何らかの意図ある仕様なのであれば，このプルリクはリジェクトしてもらって構わないのですが，私がいくつかの著名なコマンド（GNU grep, Homebrew, MRI, CPython 等）を試したところ，いずれも `--version` オプション付きの実行はステータスコード `0` を返しているようでした．